### PR TITLE
Update Go version to 1.23.6 and adjust dependencies

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.23.6"
           cache: true
 
       - name: Install dependencies

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module gocleaner
 go 1.23
 
 require (
+	github.com/go-co-op/gocron v1.37.0
 	github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible
 	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
-	github.com/go-co-op/gocron v1.37.0 // indirect
 	github.com/google/uuid v1.4.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect


### PR DESCRIPTION
Upgrade the Go version in the setup and update the dependencies in `go.mod` to ensure compatibility with the new version.